### PR TITLE
Add onnxconverter-common install to fix import issues

### DIFF
--- a/labs/MLSummit21/notebooks/1-model-training.ipynb
+++ b/labs/MLSummit21/notebooks/1-model-training.ipynb
@@ -46,7 +46,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install oracle-ads==2.5.10"
+    "!pip install oracle-ads==2.5.10\n",
+    "!pip install onnxconverter-common --upgrade"
    ]
   },
   {


### PR DESCRIPTION
When running the notebook as is, the following error is encountered when running all the module imports:
```
ModuleNotFoundError: No module named 'onnxconverter_common.auto_mixed_precision'
```

This can be fixed by running `pip install onnxconverter-common --upgrade`