### PR TITLE
Update the Jobs Java Client SDK examples

### DIFF
--- a/jobs/README.md
+++ b/jobs/README.md
@@ -2,26 +2,29 @@
 
 This project contains samples that demonstrate usage of Oracle Data Science Service Jobs.
 
-Oracle Data Science Service Jobs enables you to define and run a repeatable task on a fully managed infrastructure. The service enables custom tasks, as you can apply any use case you may have such as data preparation, model training, hyperparameter tuning, batch inference, etc.
+Oracle Data Science Service Jobs enables you to define and run a repeatable task on a fully managed infrastructure. Jobs is fully customizable and user-defined, you can apply any use case you may have such as data preparation, model training, hyperparameter tuning, batch inference, web scraping etc.
 
 Using jobs, you can:
 
 - Run Machine Learning or Data Science tasks outside of your notebooks (JupyterLab)
 - Operationalize discrete data science and machine learning tasks as reusable executable operation
 - Automate your typical MLOps or CI/CD Process
-- Execute batches or workloads triggered by events or actions
-- Batch Inference, Mini-Batch or Distributed Batch Jobs
+- Automate repeatable batches or workloads triggered by events or actions
+- Batch Inference, Mini-Batch, Distributed Batch Jobs
+- Distributed Training with Horovod, TensorFlow, PyTorch and Dask
+
+Natively Jobs support Python and Shell scripts. If you utilize Bring Your Own Container feature with jobs, you can execute any language and environment you desire.
 
 ## Introduction
 
-The job sample section contains a folder for each programing language we currently provide samples. Every language folder will contain samples of how to use the client OCI SDK:
+The repository contains set of folders for the programing languages we currently provide samples. Each folder contains codes of how to use the client OCI SDK, for example:
 
 - `cli`, `node`,`python`,`shell`, `ts+js` the programing language client SDK samples
   
-Depending on the programing language, like for example Python, we provide also sample Jobs and SDK client samples in the sub folders.
+Depending on the programing language, like for example Python, we provide also sample Jobs in the sub folders.
 
 - `sdk` showing how to use the OCI SDK Jobs API
-- `job+samples` actual code samples you could run as a Job.
+- `job+samples` actual code samples you could run as a Job
 
 ## Samples
 
@@ -29,11 +32,9 @@ This repository provides following samples:
 
 - `python` - OCI SDK samples with Jobs, as well as actual Job simple samples written in Python
 - `shell` - simple shell scripts that can be executed as Jobs
-- `ts+js` - OCI SDK TypeScript and JavaScript samples of how to use the client SDK to create and run Jobs
+- `ts+js` - client OCI SDK TypeScript and JavaScript samples of how to use to create and run Jobs
 - `zip+tar` - provides ZIP or TAR packaged samples that can be run as Jobs
-- `cli` - Oracle OCI CLI Client samples of how to use the CLI to create and run jobs
-
-
-
-
-
+- `cli` - Oracle OCI CLI Client samples of how to create and run jobs
+- `byoc` - Bring Your Own Container guide for Jobs
+- `flask_job_monitoring` - a simple application to monitor multiple Job Run logs on your local machine
+- `java` - Java client code implementing utilizing the Jobs Java OCI SDK

--- a/jobs/java/pom.xml
+++ b/jobs/java/pom.xml
@@ -30,7 +30,11 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>
         <slf4j.version>1.7.33</slf4j.version>
-        <oci-sdk.version>2.31.0</oci-sdk.version>
+        <jersey.version>2.35</jersey.version>
+        <jackson.version>2.13.1</jackson.version>
+        <jackson.databind.version>2.13.4.2</jackson.databind.version>
+        <apache-httpcomponents.httpclient.version>4.5.13</apache-httpcomponents.httpclient.version>
+        <oci-sdk.version>3.0.1</oci-sdk.version>
     </properties>
 
     <dependencies>
@@ -40,6 +44,47 @@
             <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey</artifactId>
+            <version>${oci-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${apache-httpcomponents.httpclient.version}</version>
+        </dependency>
+        <!-- OCI Java SDK -->
         <dependency>
             <groupId>com.oracle.oci.sdk</groupId>
             <artifactId>oci-java-sdk-core</artifactId>

--- a/jobs/java/src/main/java/MLJobs.java
+++ b/jobs/java/src/main/java/MLJobs.java
@@ -6,8 +6,6 @@ import com.oracle.bmc.datascience.DataScienceClient;
 import com.oracle.bmc.datascience.model.*;
 import com.oracle.bmc.datascience.requests.*;
 import com.oracle.bmc.datascience.responses.*;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.nio.file.StandardCopyOption;
@@ -39,11 +37,15 @@ public class MLJobs {
         final AuthenticationDetailsProvider provider =
                 new ConfigFileAuthenticationDetailsProvider(configWithProfile);
 
-        clientDataScience = new DataScienceClient(provider);
-        clientDataScience.setRegion(Region.US_ASHBURN_1);
+        /*
+         Old patter, which is now deprecated!
+         clientDataScience = new DataScienceClient(provider);
+         clientDataScience.setRegion(Region.US_ASHBURN_1);
+        */
+        clientDataScience = DataScienceClient.builder().region(Region.US_ASHBURN_1).build(provider);
     }
 
-    public CreateProjectResponse createProject(){
+    public CreateProjectResponse createProject() {
         CreateProjectDetails createProjectDetails =
                 CreateProjectDetails.builder()
                         .displayName("Java Project")
@@ -58,7 +60,7 @@ public class MLJobs {
         return createProjectResponse;
     }
 
-    public List<JobShapeSummary> listJobShapes(){
+    public List<JobShapeSummary> listJobShapes() {
         ListJobShapesRequest.Builder listJobShapesBuilder = ListJobShapesRequest.builder().compartmentId(COMPARTMENT_OCID);
         ListJobShapesRequest listJobShapesRequest = listJobShapesBuilder.build();
         ListJobShapesResponse listJobShapesResponse = clientDataScience.listJobShapes(listJobShapesRequest);
@@ -85,7 +87,7 @@ public class MLJobs {
     }
 
     public CreateJobResponse createJob(String jobName, String compartmentUuid,
-                                              String projectUuid, String subnetUuid) throws IOException {
+                                       String projectUuid, String subnetUuid) throws IOException {
 
         CreateJobRequest createJobRequest = null;
 
@@ -114,7 +116,7 @@ public class MLJobs {
     }
 
     public CreateJobResponse createJobWithManagedEgress(String jobName, String compartmentUuid,
-                                       String projectUuid) throws IOException {
+                                                        String projectUuid) throws IOException {
 
         CreateJobRequest createJobRequest = null;
 
@@ -146,8 +148,7 @@ public class MLJobs {
             throws IOException {
 
         final File jobArtifactFile = new File("src/main/java/hello_world_job.py");
-        final InputStream in =
-                new ByteArrayInputStream(FileUtils.readFileToByteArray(jobArtifactFile));
+        final InputStream in = new FileInputStream(jobArtifactFile);
 
         String filename = jobArtifactFile.getName();
         System.out.println("File name: " + filename);
@@ -161,7 +162,7 @@ public class MLJobs {
         return clientDataScience.createJobArtifact(createJobArtifactRequest);
     }
 
-    public void getJobArtifact (String jobUUID) throws IOException {
+    public void getJobArtifact(String jobUUID) throws IOException {
         GetJobArtifactContentRequest getJobArtifactContentRequest = GetJobArtifactContentRequest.builder().jobId(jobUUID).build();
         GetJobArtifactContentResponse getJobArtifactContentResponse = clientDataScience.getJobArtifactContent(getJobArtifactContentRequest);
 
@@ -180,23 +181,23 @@ public class MLJobs {
         return clientDataScience.headJobArtifact(headJobArtifactRequest);
     }
 
-    public GetJobResponse getJob (String JOB_UUID) {
+    public GetJobResponse getJob(String JOB_UUID) {
         GetJobRequest getJObRequest = GetJobRequest.builder().jobId(JOB_UUID).build();
         return clientDataScience.getJob(getJObRequest);
     }
 
     public UpdateJobResponse updateJob(String jobUUID) {
         UpdateJobDetails updateJobDetails = UpdateJobDetails.builder()
-                    .displayName("Java Job Update")
-                    .jobInfrastructureConfigurationDetails(
-                            StandaloneJobInfrastructureConfigurationDetails
-                                    .builder()
-                                    .shapeName("VM.Standard2.1")
-                                    .blockStorageSizeInGBs(101)
-                                    .build()
-                    )
-                    .description("Change description")
-                    .build();
+                .displayName("Java Job Update")
+                .jobInfrastructureConfigurationDetails(
+                        StandaloneJobInfrastructureConfigurationDetails
+                                .builder()
+                                .shapeName("VM.Standard2.1")
+                                .blockStorageSizeInGBs(101)
+                                .build()
+                )
+                .description("Change description")
+                .build();
 
         UpdateJobRequest updateJobRequest = UpdateJobRequest
                 .builder()
@@ -208,7 +209,7 @@ public class MLJobs {
     }
 
     public ChangeJobCompartmentResponse changeJobCompartment(String jobUUID, String compartmentUUID) {
-        ChangeJobCompartmentDetails  changeJobCompartmentDetails = ChangeJobCompartmentDetails.builder()
+        ChangeJobCompartmentDetails changeJobCompartmentDetails = ChangeJobCompartmentDetails.builder()
                 .compartmentId(compartmentUUID)
                 .build();
 
@@ -221,7 +222,7 @@ public class MLJobs {
         return clientDataScience.changeJobCompartment(changeJobCompartmentRequest);
     }
 
-    public GetJobRunResponse getJobRun (String JOB_RUN_UUID) {
+    public GetJobRunResponse getJobRun(String JOB_RUN_UUID) {
         GetJobRunRequest getJobRunRequest =
                 GetJobRunRequest.builder().jobRunId(JOB_RUN_UUID).build();
 
@@ -229,9 +230,9 @@ public class MLJobs {
     }
 
     public CreateJobRunResponse createJobRun(String jobUuid,
-                                                     String compartmentUuid,
-                                                     String projectUuid,
-                                                     String jobRunName) {
+                                             String compartmentUuid,
+                                             String projectUuid,
+                                             String jobRunName) {
         Map<String, String> envVariables = new HashMap<String, String>();
         envVariables.put("CONDA_ENV_TYPE", "service");
         envVariables.put("CONDA_ENV_SLUG", "mlcpuv1");
@@ -247,9 +248,9 @@ public class MLJobs {
                                         .displayName(jobRunName)
                                         .jobConfigurationOverrideDetails(
                                                 DefaultJobConfigurationDetails
-                                                .builder()
-                                                .environmentVariables(envVariables)
-                                                .build())
+                                                        .builder()
+                                                        .environmentVariables(envVariables)
+                                                        .build())
                                         .build())
                         .build();
         return clientDataScience.createJobRun(createJobRunRequest);
@@ -292,7 +293,7 @@ public class MLJobs {
         return clientDataScience.cancelJobRun(cancelJobRunRequest);
     }
 
-    public ListJobRunsResponse listJobRuns(String compartmentUuid){
+    public ListJobRunsResponse listJobRuns(String compartmentUuid) {
         //
         ListJobRunsRequest listJobRunsRequest =
                 ListJobRunsRequest.builder()
@@ -301,7 +302,7 @@ public class MLJobs {
         return clientDataScience.listJobRuns(listJobRunsRequest);
     }
 
-    public List<JobRunSummary> listJobRunsByState(DataScienceClient clientDataScience, String compartmentUuid){
+    public List<JobRunSummary> listJobRunsByState(DataScienceClient clientDataScience, String compartmentUuid) {
         //
         ListJobRunsRequest listJobRunsRequest =
                 ListJobRunsRequest.builder()

--- a/jobs/java/src/main/java/Test.java
+++ b/jobs/java/src/main/java/Test.java
@@ -1,14 +1,8 @@
-import com.oracle.bmc.ConfigFileReader;
-import com.oracle.bmc.Region;
-import com.oracle.bmc.auth.AuthenticationDetailsProvider;
-import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider;
-import com.oracle.bmc.datascience.DataScienceClient;
 import com.oracle.bmc.datascience.responses.CreateJobArtifactResponse;
 import com.oracle.bmc.datascience.responses.CreateJobResponse;
 import com.oracle.bmc.datascience.responses.CreateJobRunResponse;
 import com.oracle.bmc.datascience.responses.GetJobResponse;
 import com.oracle.bmc.datascience.model.*;
-import com.oracle.bmc.datascience.requests.*;
 import com.oracle.bmc.datascience.responses.*;
 
 import java.io.IOException;
@@ -81,7 +75,7 @@ public class Test {
         System.out.println("getOpcRequestId: " + headJobArtifactResponse.getOpcRequestId());
 
         // Get Job Artifact
-        // TODO: how to download and store!
+        // TODO: download and store artifact!
 
         // List Job Shapes
         System.out.println("* LIST JOB SHAPES");

--- a/jobs/java/src/main/java/TestDelete.java
+++ b/jobs/java/src/main/java/TestDelete.java
@@ -1,10 +1,4 @@
-import com.oracle.bmc.datascience.model.JobRunSummary;
-import com.oracle.bmc.datascience.model.JobShapeSummary;
-import com.oracle.bmc.datascience.model.JobSummary;
-import com.oracle.bmc.datascience.responses.*;
-
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Client ML Jobs delete test.

--- a/jobs/java/src/main/java/job_java.java
+++ b/jobs/java/src/main/java/job_java.java
@@ -41,7 +41,7 @@ public class job_java {
             }
 
             System.out.println("Log Client");
-            LoggingClient loggingClient = new LoggingClient(provider);
+            LoggingClient loggingClient = LoggingClient.builder().build(provider);
             loggingClient.setRegion(Region.US_ASHBURN_1);
 
             LogEntry logEntry = LogEntry.builder()


### PR DESCRIPTION
- bump the Java OCI SDK version
- comply the code with the builder patter, remove deprecations, fix pom dependancies 