### PR TITLE
Update Job monitor

### DIFF
--- a/jobs/flask_job_monitor/job_monitor.py
+++ b/jobs/flask_job_monitor/job_monitor.py
@@ -12,7 +12,6 @@ import yaml
 from ads.common.oci_datascience import OCIDataScienceMixin
 from ads.common.oci_resource import OCIResource
 from ads.jobs import DataScienceJobRun, Job
-from ads.opctl.cmds import run as opctl_run
 from flask import Flask, request, abort, jsonify, render_template
 
 
@@ -361,6 +360,14 @@ def load_yaml(filename=None):
 
 @app.route("/run", methods=["POST"])
 def run():
+    auth = get_authentication()
+    from ads.opctl.cmds import run as opctl_run
+    # The following line is added for security reason.
+    if not auth["config"]:
+        abort(
+            403,
+            "Starting a workflow is only available when you launch the app locally with OCI API key."
+        )
     try:
         workflow = yaml.safe_load(urllib.parse.unquote(request.data[5:].decode()))
 

--- a/jobs/flask_job_monitor/job_monitor.py
+++ b/jobs/flask_job_monitor/job_monitor.py
@@ -221,7 +221,7 @@ def init_components(compartment_id, project_id):
 @app.route("/<compartment_id>/<project_id>")
 def job_monitor(compartment_id=None, project_id=None):
     if project_id == "favicon.ico":
-        abort(404)
+        redirect("https://www.oracle.com/favicon.ico")
 
     context = init_components(compartment_id, project_id)
     return render_template(

--- a/jobs/flask_job_monitor/job_monitor.py
+++ b/jobs/flask_job_monitor/job_monitor.py
@@ -221,7 +221,7 @@ def init_components(compartment_id, project_id):
 @app.route("/<compartment_id>/<project_id>")
 def job_monitor(compartment_id=None, project_id=None):
     if project_id == "favicon.ico":
-        redirect("https://www.oracle.com/favicon.ico")
+        return redirect("https://www.oracle.com/favicon.ico")
 
     context = init_components(compartment_id, project_id)
     return render_template(

--- a/jobs/flask_job_monitor/static/dashboard.js
+++ b/jobs/flask_job_monitor/static/dashboard.js
@@ -80,6 +80,12 @@ function updateLogs(ocid, outputDiv, stopped) {
       setTimeout(function () {
         updateLogs(ocid, outputDiv, true);
       }, LOG_CHECKING_INTERVAL);
+      setTimeout(function () {
+        updateLogs(ocid, outputDiv, true);
+      }, LOG_CHECKING_INTERVAL * 2);
+      setTimeout(function () {
+        updateLogs(ocid, outputDiv, true);
+      }, LOG_CHECKING_INTERVAL * 3);
     }
   })
 }

--- a/jobs/flask_job_monitor/templates/job_run_template.html
+++ b/jobs/flask_job_monitor/templates/job_run_template.html
@@ -50,11 +50,26 @@
       <!-- Modal content-->
       <div class="modal-content">
         <div class="modal-header">
-          <h4 class="modal-title">{{ job.name}}</h4>
+          <h4 class="modal-title">Job Run - {{ run.name}}</h4>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <pre style="overflow-x: scroll;"><code class="language-yaml">{{ job|safe }}</code></pre>
+          <pre style="overflow-x: scroll;"><code class="language-yaml">{{ run|safe }}</code></pre>
+          <hr>
+          <div class="accordion" id="accordionJobYaml">
+            <div class="accordion-item">
+              <h2 class="accordion-header" id="headingJobYaml">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseJobYaml" aria-expanded="false" aria-controls="collapseJobYaml">
+                  Job YAML - {{ job.name }}
+                </button>
+              </h2>
+              <div id="collapseJobYaml" class="accordion-collapse collapse" aria-labelledby="headingJobYaml" data-bs-parent="#accordionJobYaml">
+                <div class="accordion-body">
+                  <pre style="overflow-x: scroll;"><code class="language-yaml">{{ job|safe }}</code></pre>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/jobs/flask_job_monitor/templates/run_workflow.html
+++ b/jobs/flask_job_monitor/templates/run_workflow.html
@@ -97,7 +97,7 @@
               url: "/run",
               data: { yaml: editor.getValue() },
             }).fail(function(data) {
-              toastMessage("Error", data.error);
+              toastMessage("Error", data.responseJSON.error);
             }).done(function(data) {
               toastMessage(
                 "Job Created",

--- a/jobs/flask_job_monitor/templates/run_workflow.html
+++ b/jobs/flask_job_monitor/templates/run_workflow.html
@@ -51,7 +51,7 @@
 
         function initEditor() {
           return monaco.editor.create(document.getElementById('container'), {
-            value: 'kind: job\nspec:\n',
+            value: 'kind: job\nspec:\n  infrastructure:\n    type: dataScienceJob\n',
             language: 'yaml',
             theme: 'vs-dark',
             automaticLayout: true
@@ -87,7 +87,7 @@
               var workflow = jsyaml.load(editor.getValue());
               toastMessage("Creating Workflow ...", workflow.kind + " - " + workflow.spec.infrastructure.type);
             } catch (err) {
-              console.log(err);
+              toastMessage(err);
               return;
             }
 
@@ -96,8 +96,8 @@
               contentType: "application/json",
               url: "/run",
               data: { yaml: editor.getValue() },
-            }).fail(function() {
-              toastMessage("Error Occurred", "Your workflow may not be started correctly.");
+            }).fail(function(data) {
+              toastMessage("Error", data.error);
             }).done(function(data) {
               toastMessage(
                 "Job Created",
@@ -106,10 +106,6 @@
             });
           });
         })
-
-
-
-
       </script>
     </div>
   </div>


### PR DESCRIPTION
A few updates on the job monitor app:
* Show job run configuration, including overwritten environment variables when viewing job YAML.
* Return json payload instead of plain text when there is an error.
* In the compartments dropdown list, show only the first level compartments if user does not have permission to list all sub-compartments.
* Redirect `/favicon.ico` to `www.oracle.com/favicon.ico`.
* Restrict `Run Workflow` feature to API Key authentication only.