### PR TITLE
Add example notebook to show running a jupyter notebook using jobs

### DIFF
--- a/notebook_examples/run_notebook-jobs.ipynb
+++ b/notebook_examples/run_notebook-jobs.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ab25247b",
+   "metadata": {},
+   "source": [
+    "@notebook{run_notebook-jobs.ipynb,\n",
+    "    title: Run a notebook with Jobs,\n",
+    "    summary: Run a notebook with OCI data science jobs,\n",
+    "    developed on: pytorch110_p37_cpu_v1,\n",
+    "    keywords: Run Notebook, Jobs,\n",
+    "    license: Universal Permissive License v 1.0\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07384018",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upgrade Oracle ADS to pick up latest features and maintain compatibility with Oracle Cloud Infrastructure.\n",
+    "\n",
+    "!pip install -U oracle-ads"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9800984",
+   "metadata": {},
+   "source": [
+    "<font color=gray>Oracle Data Science service sample notebook.\n",
+    "\n",
+    "Copyright (c) 2022 Oracle, Inc.  All rights reserved.\n",
+    "Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.\n",
+    "</font>\n",
+    "\n",
+    "***\n",
+    "# <font color=red>Run a Notebook with Jobs</font>\n",
+    "<p style=\"margin-left:10%; margin-right:10%;\">by the <font color=teal> Oracle Cloud Infrastructure Data Science Service Team </font></p>\n",
+    "\n",
+    "***\n",
+    "\n",
+    "## Overview:\n",
+    "\n",
+    "Oracle Cloud Infrastructure (OCI) [Data Science jobs](https://docs.oracle.com/en-us/iaas/data-science/using/jobs-about.htm) enable you to define and run a repeatable machine learning task on a fully managed infrastructure. This notebook shows you how to use the [Accelerated Data Science (ADS) SDK](https://accelerated-data-science.readthedocs.io/en/latest/) to run a Jupyter notebook using OCI data science jobs and download the outputs.\n",
+    "\n",
+    "Developed on [General Machine Learning](https://docs.oracle.com/iaas/data-science/using/conda-gml-fam.htm) for CPU on Python 3.8 (version 1.0)\n",
+    "\n",
+    "### Prerequisites\n",
+    "\n",
+    "* This notebook requires internet egress to download the notebook and sample dataset\n",
+    "* This notebook requires authorization to work with the OCI Data Science Service. Details can be found [here](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/cli/authentication.html#). This notebook uses resource principals for authentication.\n",
+    "* This notebook requires access to OCI object storage. Refer how to setup policy for managing Object Storage service resource [here](https://docs.oracle.com/en-us/iaas/Content/Identity/policiescommon/commonpolicies.htm#write-objects-to-buckets)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Datasets are provided as a convenience. Datasets are considered third-party content and are not considered materials under your agreement with Oracle.\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c86185b9",
+   "metadata": {},
+   "source": [
+    "### Introduction\n",
+    "\n",
+    "We can debug a notebook with a small dataset on OCI data science notebook session using a CPU shape and scale up to process a larger dataset on OCI data science jobs using GPU shape. For this example, we will use OCI data science jobs to run our example notebook: [XGBoost with RAPIDS](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/master/notebook_examples/xgboost-with-rapids.ipynb), which shows that we can use GPU to speedup the training time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2917ee3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ads\n",
+    "from ads.jobs import Job, DataScienceJob, NotebookRuntime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24356e25",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n",
+    "Authentication to the OCI Data Science service is required. Here we configure ADS to use resource principals for authentication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2c58c5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ads.set_auth(auth=\"resource_principal\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fe0fce3",
+   "metadata": {},
+   "source": [
+    "## Configure Notebook Runtime\n",
+    "\n",
+    "The ADS `NotebookRuntime` class provides APIs to configure the job to run a notebook. The `path` of the notebook can be a local file path or a URI, including OCI object storage(`oci://bucket@namespace/path/to/notebook`). Here we will use the raw GitHub http URL. Optionally you can specify the `encoding` of the notebook (`utf-8` will be used by default). We would like to run this notebook with the NVIDIA RAPIDS 21.10 for GPU on Python 3.7 (`rapids2110_p37_gpu_v1`) conda environment provided by the OCI data science service."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad759dc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "notebook_runtime = (\n",
+    "    NotebookRuntime()\n",
+    "    .with_notebook(\n",
+    "        path=\"https://github.com/oracle-samples/oci-data-science-ai-samples/raw/master/notebook_examples/xgboost-with-rapids.ipynb\",\n",
+    "        encoding=\"utf-8\"\n",
+    "    )\n",
+    "    .with_service_conda(\"rapids2110_p37_gpu_v1\")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a79c4080",
+   "metadata": {},
+   "source": [
+    "The `NotebookRuntime` also provide options to save the notebook and outputs to object storage once the job finished. You can specify the output location using the `with_output` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4267aae8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Update the OUTPUT_URI to your object storage location to save the notebook outputs.\n",
+    "OUTPUT_URI = \"\" # oci://bucket@namespace/path/to/dir/\n",
+    "\n",
+    "if OUTPUT_URI:\n",
+    "    notebook_runtime.with_output(OUTPUT_URI)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "796cfaca",
+   "metadata": {},
+   "source": [
+    "## Define, Create, Run and Watch the Job\n",
+    "\n",
+    "Here we define the job intrastructure to use a GPU shape and configure logging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eda7c667",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set the LOG_GROUP_ID and LOG_ID to the ones in your tenancy.\n",
+    "LOG_GROUP_ID = \"ocid1.loggroup.oc1.iad.xxxxx\"\n",
+    "LOG_ID = \"ocid1.log.oc1.iad.xxxxx\"\n",
+    "\n",
+    "\n",
+    "job = (\n",
+    "    Job()\n",
+    "    .with_infrastructure(\n",
+    "        DataScienceJob()\n",
+    "        .with_shape_name(\"VM.GPU2.1\")\n",
+    "        .with_log_group_id(LOG_GROUP_ID)\n",
+    "        .with_log_id(LOG_ID)\n",
+    "        # The following infrastructure configurations are optional\n",
+    "        # if you are in an OCI data science notebook session.\n",
+    "        # The configurations of the notebook session will be used as defaults\n",
+    "        # .with_compartment_id(\"<compartment_ocid>\")\n",
+    "        # .with_project_id(\"<project_ocid>\")\n",
+    "    )\n",
+    "    .with_runtime(notebook_runtime)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45e1f71d",
+   "metadata": {},
+   "source": [
+    "Create and run the job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f9c012a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run = job.create().run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f21b5716",
+   "metadata": {},
+   "source": [
+    "Watch the job to stream outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5390b78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.watch()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dca33711",
+   "metadata": {},
+   "source": [
+    "## Job Outputs\n",
+    "\n",
+    "Once the job finished, you can download the outputs to local directory. The job outputs will always contain the notebook with all outputs in the cells. If your notebook create files under the working directory of the notebook (using relative paths), they will also be included in the outputs. The following code downloads the outputs to `/home/datascience/outputs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41932b0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download the outputs to /home/datascience/outputs\n",
+    "run.download(\"/home/datascience/outputs\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41a9a5c6",
+   "metadata": {},
+   "source": [
+    "<a id='ref'></a>\n",
+    "# References\n",
+    "- [ADS Library Documentation](https://accelerated-data-science.readthedocs.io/en/latest/index.html)\n",
+    "- [ADS Documentation: Data Science Jobs](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/jobs/index.html)\n",
+    "- [ADS Documentation: Run a notebook on Data Science Jobs](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/jobs/run_notebook.html)\n",
+    "- [Data Science YouTube Videos](https://www.youtube.com/playlist?list=PLKCk3OyNwIzv6CWMhvqSB_8MLJIZdO80L)\n",
+    "- [OCI Data Science Documentation](https://docs.cloud.oracle.com/en-us/iaas/data-science/using/data-science.htm)\n",
+    "- [Oracle Data & AI Blog](https://blogs.oracle.com/datascience/)\n",
+    "- [Understanding Conda Environments](https://docs.cloud.oracle.com/en-us/iaas/data-science/using/use-notebook-sessions.htm#conda_understand_environments)\n",
+    "- [Use Resource Manager to Configure Your Tenancy for Data Science](https://docs.cloud.oracle.com/en-us/iaas/data-science/using/orm-configure-tenancy.htm)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:generalml_p38_cpu_v1]",
+   "language": "python",
+   "name": "conda-env-generalml_p38_cpu_v1-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adding an example notebook to show how to run a Jupyter notebook using OCI data science jobs.
The example notebook include steps to:
* Configure ADS`NotebookRuntime` to run Jupyter notebook from GitHub
* Configure ADS`DataScienceJob` to use logging and GPU VM
* Run the [xgboost-with-rapids.ipynb](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/master/notebook_examples/xgboost-with-rapids.ipynb) notebook as a job
* Stream the job logs
* Save the notebook with outputs into OCI object storage
* Download the outputs to local directory