### PR TITLE
pass stream to create_model_artifact

### DIFF
--- a/model_catalog_examples/notebook_examples/uploading_larger_artifact_oci_python_sdk.ipynb
+++ b/model_catalog_examples/notebook_examples/uploading_larger_artifact_oci_python_sdk.ipynb
@@ -145,9 +145,8 @@
    "outputs": [],
    "source": [
     "with open(artifact_path,'rb') as artifact_file:\n",
-    "    artifact_bytes = artifact_file.read()\n",
     "    data_science.create_model_artifact(model_id,\n",
-    "                                       artifact_bytes,\n",
+    "                                       artifact_file,\n",
     "                                       content_disposition='attachment; filename=\"{artifact_path}\"')"
    ]
   },


### PR DESCRIPTION
This [blog post](https://blogs.oracle.com/ai-and-datascience/post/solution-for-timeout-error-while-uploading-larger-size-model-artifact) is outdated now but users are continuing to refer to it. Main issue:
The blog is referring users to this [example notebook](https://github.com/oracle/oci-data-science-ai-samples/blob/master/model_catalog_examples/notebook_examples/uploading_larger_artifact_oci_python_sdk.ipynb), in which the entire model is read into the memory and then passed into the OCI SDK. However, the correct way to avoid the timeout issue should be passing the “stream” or file-like object into the OCI Python SDK instead. There is no need to set timeout value except for really slow internet connection.

### Testing
<img width="880" alt="Screenshot 2023-10-24 at 3 41 20 PM" src="https://github.com/oracle-samples/oci-data-science-ai-samples/assets/25996703/d9bbda1f-8e1a-40c5-aaaf-9469cd75e210">
<img width="1221" alt="image" src="https://github.com/oracle-samples/oci-data-science-ai-samples/assets/25996703/15b2714a-edd1-4b98-b49b-f24597797617">

