### PR TITLE
[ODSC-49121]update with the latest module

### DIFF
--- a/model_catalog_examples/notebook_examples/uploading_larger_artifact_oracle_ads.ipynb
+++ b/model_catalog_examples/notebook_examples/uploading_larger_artifact_oracle_ads.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "<font color=gray>Oracle Cloud Infrastructure Data Science Sample Notebook\n",
     "\n",
-    "Copyright (c) 2021 Oracle, Inc.  All rights reserved. <br>\n",
+    "Copyright (c) 2021, 2023 Oracle, Inc.  All rights reserved. <br>\n",
     "Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.\n",
     "</font>"
    ]
@@ -35,16 +35,7 @@
    "id": "9325ef67",
    "metadata": {},
    "source": [
-    "* We recommend that you run this notebook in a notebook session using a conda environment that has ADS version 2.3.1 installed\n",
-    "* You need access to the public internet\n",
-    "\n",
-    "***\n",
-    " \n",
-    "<font color=gray>Datasets are provided as a convenience. Datasets are considered Third Party Content and are not considered Materials under your agreement with Oracle applicable to the Services.\n",
-    " \n",
-    "The dataset `oracle_classification_dataset1` is distributed under the [UPL license](oracle_data/UPL.txt). \n",
-    "</font>\n",
-    "***"
+    "* We recommend that you run this notebook in a notebook session using a conda environment that has ADS version 2.8.10 installed"
    ]
   },
   {
@@ -54,31 +45,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ads\n",
-    "import logging\n",
-    "import os\n",
-    "import tempfile\n",
-    "import warnings\n",
-    "\n",
-    "from ads.catalog.model import ModelCatalog\n",
-    "from ads.common.model import ADSModel\n",
-    "from ads.common.model_export_util import prepare_generic_model\n",
-    "from ads.common.model_metadata import (MetadataCustomCategory,\n",
-    "                                       UseCaseType,\n",
-    "                                       Framework)\n",
-    "from ads.dataset.factory import DatasetFactory\n",
-    "from ads.feature_engineering.schema import Expression, Schema\n",
-    "from os import path\n",
     "from sklearn.ensemble import RandomForestClassifier\n",
-    "\n",
-    "logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.ERROR)\n",
-    "warnings.filterwarnings('ignore')\n",
-    "ads.set_documentation_mode(False)"
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "import ads\n",
+    "import os"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "e49fd60d",
    "metadata": {},
    "outputs": [],
@@ -95,19 +71,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load the dataset\n",
-    "ds_path = path.join(\"/\", \"opt\", \"notebooks\", \"ads-examples\", \"oracle_data\", \"oracle_classification_dataset1_150K.csv\")\n",
-    "\n",
-    "ds = DatasetFactory.open(ds_path, target=\"class\")\n",
-    "\n",
-    "ds\n",
-    "# Data preprocessing\n",
-    "transformed_ds = ds.auto_transform(fix_imbalance=False)\n",
-    "train, test = transformed_ds.train_test_split(test_size=0.15)\n",
-    "\n",
-    "# Build the model and convert it to an ADSModel object\n",
-    "rf_clf = RandomForestClassifier(n_estimators=10).fit(train.X.values, train.y.values)\n",
-    "rf_model = ADSModel.from_estimator(rf_clf)"
+    "seed = 42\n",
+    "# make some classification data\n",
+    "X, y = make_classification(n_samples=10000, n_features=15, n_classes=2, flip_y=0.05)\n",
+    "trainx, testx, trainy, testy = train_test_split(X, y, test_size=30, random_state=seed)\n",
+    "model = RandomForestClassifier(\n",
+    "        n_estimators=100, random_state=42\n",
+    "    )\n",
+    "# train a random forest classifier\n",
+    "model.fit(\n",
+    "        trainx,\n",
+    "        trainy,\n",
+    "    )"
    ]
   },
   {
@@ -118,11 +93,17 @@
    "outputs": [],
    "source": [
     "# Prepare the model artifacts\n",
-    "path_to_ADS_model_artifact = tempfile.mkdtemp()\n",
+    "from ads.model.framework.sklearn_model import SklearnModel\n",
+    "from ads.common.model_metadata import UseCaseType\n",
     "\n",
-    "rf_model_artifact = rf_model.prepare(path_to_ADS_model_artifact, use_case_type=UseCaseType.BINARY_CLASSIFICATION,\n",
-    "                                     force_overwrite=True, data_sample=test, data_science_env=True,\n",
-    "                                     fn_artifact_files_included=False)"
+    "sklearn_model = SklearnModel(estimator=model, artifact_dir=\"~/sklearn_artifact_dir\")\n",
+    "sklearn_model.prepare(\n",
+    "    inference_conda_env=\"generalml_p38_cpu_v1\",\n",
+    "    training_conda_env=\"generalml_p38_cpu_v1\",\n",
+    "    X_sample=trainx,\n",
+    "    y_sample=trainy,\n",
+    "    use_case_type=UseCaseType.BINARY_CLASSIFICATION,\n",
+    ")"
    ]
   },
   {
@@ -133,13 +114,12 @@
    "outputs": [],
    "source": [
     "# Saving the model artifact to the model catalog:\n",
-    "mc_model = rf_model_artifact.save(project_id=os.environ['PROJECT_OCID'],\n",
+    "mc_model = sklearn_model.save(project_id=os.environ['PROJECT_OCID'],\n",
     "                                  compartment_id=os.environ['NB_SESSION_COMPARTMENT_OCID'],\n",
     "                                  training_id=os.environ['NB_SESSION_OCID'],\n",
     "                                  display_name=\"<replace-with-your-display-name>\",\n",
     "                                  description=\"<replace-with-description>\",\n",
     "                                  ignore_pending_changes=True,\n",
-    "                                  timeout=1800,\n",
     "                                  ignore_introspection=True,\n",
     "                                 )\n",
     "mc_model"
@@ -156,9 +136,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:dataexpl_p37_cpu_v2]",
+   "display_name": "ads_testing",
    "language": "python",
-   "name": "conda-env-dataexpl_p37_cpu_v2-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -170,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,

--- a/model_catalog_examples/notebook_examples/uploading_larger_artifact_oracle_ads.ipynb
+++ b/model_catalog_examples/notebook_examples/uploading_larger_artifact_oracle_ads.ipynb
@@ -121,6 +121,7 @@
     "                                  description=\"<replace-with-description>\",\n",
     "                                  ignore_pending_changes=True,\n",
     "                                  ignore_introspection=True,\n",
+    "                                  bucket_uri=\"oci://<replace-with-your-bucket-name>\",\n",
     "                                 )\n",
     "mc_model"
    ]


### PR DESCRIPTION
It is still showing the old way of using ADS to save the model (deprecated since 2.6.6), which is also reading the entire file before passing it into OCI SDK. This issue has been fixed in the [new framework specific way](https://accelerated-data-science.readthedocs.io/en/latest/user_guide/model_registration/quick_start.html) of saving models.


### Testing
<img width="974" alt="Screenshot 2023-10-24 at 5 00 56 PM" src="https://github.com/oracle-samples/oci-data-science-ai-samples/assets/25996703/a4abeb9c-beb5-4a7c-a96f-26d94c51ab7b">
