### PR TITLE
Update check-copyright.py to check only user modified files.

### DIFF
--- a/.pre-commit-scripts/check-copyright.py
+++ b/.pre-commit-scripts/check-copyright.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2023 Oracle and/or its affiliates.
+# Copyright (c) 2023, 2024 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 import datetime
@@ -40,5 +40,7 @@ def main(filenames) -> int:
 
 
 if __name__ == "__main__":
-    filenames = sys.argv
-    main(filenames)
+    if len(sys.argv) > 1:
+        # The first element in argv list is the name of this check-copyright.py script.
+        filenames = sys.argv[1:]
+        main(filenames)


### PR DESCRIPTION
Currently the `check-copyright.py` is checking all filenames contained in `sys.argv`. However, `sys.argv[0]` is the filename of the `check-copyright.py` script. We should not check this script. Especially when this script itself may fail the copyright check in the new year :) (like missing the 2024 copyright).