### PR TITLE
Fixes to action yaml in tests for check_copyright pre-commit

### DIFF
--- a/.github/workflows/test_check_copyright.yml
+++ b/.github/workflows/test_check_copyright.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        python-version: "3.10"
+        with:
+          python-version: "3.10"
       - shell: bash
         run: |
           set -x # print commands that are executed


### PR DESCRIPTION
### Description

After merged https://github.com/oracle-samples/oci-data-science-ai-samples/pull/382 to main, gh actions added to main and any issues can be fixed and checked. This Pr is to fix any observed error in tests action for copyright pre-commit.

### Waht was done

- fixed python-version in actions/setup-python@v4

### Validation

Test action works as expected and copyright tests passed:
https://github.com/oracle-samples/oci-data-science-ai-samples/actions/runs/7478136881
![image](https://github.com/oracle-samples/oci-data-science-ai-samples/assets/49763871/32494432-e59b-4076-893e-f44f17f135ff)
