### PR TITLE
Updating Index.json and Readme.md file to reflect the new notebook train-mysql-heatwave-deploy-xgboost.ipynb

### DIFF
--- a/notebook_examples/README.md
+++ b/notebook_examples/README.md
@@ -64,7 +64,7 @@ The ADS SDK can be downloaded from [PyPi](https://pypi.org/project/oracle-ads/),
  - [Using feature store for synthetic data generation using openai](#feature_store_medical_synthetic_data_openai.ipynb)
  - [Working with Pipelines](#pipelines-ml_lifecycle.ipynb)
  - [XGBoost with RAPIDS](#xgboost-with-rapids.ipynb)
-
+ - [XGBoost for MySQL Heatwave](#train-mysql-heatwave-deploy-xgboost.ipynb)
 
 ## Notebooks
 ### <a name="automlx-anomaly_detection.ipynb"></a> - Building and Explaining an Anomaly Detector using AutoMLx - Experimental

--- a/notebook_examples/index.json
+++ b/notebook_examples/index.json
@@ -705,5 +705,22 @@
     "summary": "Train, register, and deploy an XGBoost model.",
     "time_created": "2023-03-26T22:51:01",
     "title": "Train, Register, and Deploy an XGBoost Model"
+  },
+    {
+    "developed_on": "generalml_p311_cpu_x86_64_v1",
+    "filename": "train-mysql-heatwave-deploy-xgboost.ipynb",
+    "keywords": [
+      "xgboost",
+      "deploy model",
+      "mysql heatwave",
+      "linear regression",
+      "random forest",
+      "train model"
+    ],
+    "license": "Universal Permissive License v 1.0",
+    "size": 12075,
+    "summary": "Train and Deploy an XGBoost Model for OCI MySQL Heatwave.",
+    "time_created": "2025-02-19T22:51:01",
+    "title": "Train and Deploy an XGBoost Model for OCI MySQL Heatwave."
   }
 ]


### PR DESCRIPTION
After successfully merging `train-mysql-heatwave-deploy-xgboost.ipynb` in main branch, we noticed that the new notebook is not reflecting in the Notebook Explorer of OCI Data Science. The fix was identified to update the index.json and Readme.md file with the details on the new notebook.

Appreciate your review and approval. 

@darenr @mrDzurb 