### PR TITLE
Corrected: Additional Details Added to Aqua Troubleshooting Documentation For Auth Errors

### DIFF
--- a/ai-quick-actions/troubleshooting-tips.md
+++ b/ai-quick-actions/troubleshooting-tips.md
@@ -1,5 +1,4 @@
 
-# Troubleshooting Model Deployment
 
 <!-- TOC -->
 <!-- /TOC -->
@@ -33,6 +32,7 @@
       - [List Buckets](#list-buckets)
       - [Update Model](#update-model)
       - [Evaluation and Fine Tuning](#evaluation-and-fine-tuning)
+# Troubleshooting Model Deployment
 
 ## Logs
 


### PR DESCRIPTION
Added details to generally troubleshoot auth errors in AQUA. Added headers to allow us to throw errors from AQUA directly referencing solutions on the troubleshooting page.

For example:
if error is 404, list_log_groups --> we directly link the troubleshooting page and the section "list log group" within the Authorization Errors section.