### PR TITLE
Updating Aqua release notes

### DIFF
--- a/ai-quick-actions/ai-quick-actions-containers.md
+++ b/ai-quick-actions/ai-quick-actions-containers.md
@@ -2,10 +2,11 @@
 
 | Server                                                                                                          | Version     |Supported Formats|Supported Shapes| Supported Models/Architectures                                                                                                  |
 |-----------------------------------------------------------------------------------------------------------------|-------------|-----------------|----------------|---------------------------------------------------------------------------------------------------------------------------------|
-| [vLLM](https://github.com/vllm-project/vllm/releases/tag/v0.6.4.post1)                                          | 0.6.4.post1 |safe-tensors|A10, A100, H100| [v0.6.4.post1 supported models](https://docs.vllm.ai/en/v0.6.4.post1/models/supported_models.html)                   |
-| [vLLM](https://github.com/vllm-project/vllm/releases/tag/v0.7.1)                                          | 0.8.1 |safe-tensors|A10, A100, H100| [v0.8.1 supported models](https://docs.vllm.ai/en/v0.8.1/models/supported_models.html)                   |
+| [vLLM](https://github.com/vllm-project/vllm/releases/tag/v0.6.4.post1)                                          | 0.6.4.post1 |safe-tensors|A10, A100, H100| [v0.6.4.post1 supported models](https://docs.vllm.ai/en/v0.6.4.post1/models/supported_models.html)                              |
+| [vLLM](https://github.com/vllm-project/vllm/releases/tag/v0.8.1)                                                | 0.8.1       |safe-tensors|A10, A100, H100| [v0.8.1 supported models](https://docs.vllm.ai/en/v0.8.1/models/supported_models.html)                                          |
+| [vLLM](https://github.com/vllm-project/vllm/releases/tag/v0.8.3)                                                | 0.8.3       |safe-tensors|A10, A100, H100| [v0.8.3 supported models](https://docs.vllm.ai/en/v0.8.3_a/models/supported_models.html)                                          |
 | [Text Generation Inference (TGI)](https://github.com/huggingface/text-generation-inference/releases/tag/v2.0.1) | 2.0.1.4     |safe-tensors|A10, A100, H100| [v2.0.1 supported models](https://github.com/huggingface/text-generation-inference/blob/v2.0.1/docs/source/supported_models.md) |
-| [Llama-cpp](https://github.com/abetlen/llama-cpp-python/releases/tag/v0.3.5)                                    | 0.3.5     |gguf|Amphere ARM| [v0.3.5 supported models](https://github.com/abetlen/llama-cpp-python/tree/v0.3.5)      |
+| [Llama-cpp](https://github.com/abetlen/llama-cpp-python/releases/tag/v0.3.5)                                    | 0.3.5       |gguf|Amphere ARM| [v0.3.5 supported models](https://github.com/abetlen/llama-cpp-python/tree/v0.3.5)                                              |
 
 
 <!-- 

--- a/ai-quick-actions/release-notes.md
+++ b/ai-quick-actions/release-notes.md
@@ -1,16 +1,14 @@
 # AI Quick Actions Release Notes
 
 
-## v1.0.7 (Released February April 23, 2025)
+## v1.0.7 (Released April 23, 2025)
 **Highlights:**
 - **UI Enhancements:**
   - We have made UI improvements based on customer feedback to enhance troubleshooting experience. 
     - User will be able to copy the error payload for faster resolution and sharing.
-    - Improved Model registration , Deployment and Evaluation flow using metadata APIs
+  - Improved Model registration , Deployment and Evaluation flow using metadata APIs
 
 To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
-
-For more details, refer to the corresponding [Oracle release notes](https://docs.oracle.com/en-us/iaas/releasenotes/data-science/ai-quick-actions-106-b.htm).
 
 
 ## v1.0.6d (Released February April 17, 2025)
@@ -21,10 +19,10 @@ For more details, refer to the corresponding [Oracle release notes](https://docs
   - Upgraded managed containers are now running [vLLM 0.8.3](https://github.com/vllm-project/vllm/releases/tag/v0.8.3). This version of vLLM supports the newly released Meta's Llama 4 models. 
 - **UI Enhancements:**
   - We have made UI improvements based on customer feedback and to better help customers troubleshoot, including link to the AI Quick Actions [Troubleshooting page](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md). 
+- **AQUA CLI Enhancements:**
+  - Added support for creating deployments with multiple verified or cached LLM (text-generation) models using the AI Quick Actions CLI. For more details, refer to the corresponding [AI Quick Actions MultiModel Deployment documentation](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md).
 
 To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
-
-For more details, refer to the corresponding [Oracle release notes](https://docs.oracle.com/en-us/iaas/releasenotes/data-science/ai-quick-actions-106-b.htm).
 
 
 ## v1.0.6b (Released February 28, 2025)

--- a/ai-quick-actions/release-notes.md
+++ b/ai-quick-actions/release-notes.md
@@ -7,6 +7,8 @@
   - We have made UI improvements based on customer feedback to enhance troubleshooting experience. 
     - User will be able to copy the error payload for faster resolution and sharing.
   - Improved Model registration , Deployment and Evaluation flow using metadata APIs
+- **AQUA CLI Enhancements:**
+  - Added support for creating deployments with multiple verified or cached LLM (text-generation) models using the AI Quick Actions CLI. For more details, refer to the corresponding [AI Quick Actions MultiModel Deployment documentation](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md).
 
 To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
 
@@ -19,8 +21,6 @@ To get this version of AI Quick Actions, deactivate and reactivate your notebook
   - Upgraded managed containers are now running [vLLM 0.8.3](https://github.com/vllm-project/vllm/releases/tag/v0.8.3). This version of vLLM supports the newly released Meta's Llama 4 models. 
 - **UI Enhancements:**
   - We have made UI improvements based on customer feedback and to better help customers troubleshoot, including link to the AI Quick Actions [Troubleshooting page](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md). 
-- **AQUA CLI Enhancements:**
-  - Added support for creating deployments with multiple verified or cached LLM (text-generation) models using the AI Quick Actions CLI. For more details, refer to the corresponding [AI Quick Actions MultiModel Deployment documentation](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/multimodel-deployment-tips.md).
 
 To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
 

--- a/ai-quick-actions/release-notes.md
+++ b/ai-quick-actions/release-notes.md
@@ -1,5 +1,32 @@
 # AI Quick Actions Release Notes
 
+
+## v1.0.7 (Released February April 23, 2025)
+**Highlights:**
+- **UI Enhancements:**
+  - We have made UI improvements based on customer feedback to enhance troubleshooting experience. 
+    - User will be able to copy the error payload for faster resolution and sharing.
+    - Improved Model registration , Deployment and Evaluation flow using metadata APIs
+
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+For more details, refer to the corresponding [Oracle release notes](https://docs.oracle.com/en-us/iaas/releasenotes/data-science/ai-quick-actions-106-b.htm).
+
+
+## v1.0.6d (Released February April 17, 2025)
+**Highlights:**
+- **Cached Model Upgrade:**
+  - Introduced Phi 4 and Phi 3.5 as a service cached model.
+- **Container Enhancements:**
+  - Upgraded managed containers are now running [vLLM 0.8.3](https://github.com/vllm-project/vllm/releases/tag/v0.8.3). This version of vLLM supports the newly released Meta's Llama 4 models. 
+- **UI Enhancements:**
+  - We have made UI improvements based on customer feedback and to better help customers troubleshoot, including link to the AI Quick Actions [Troubleshooting page](https://github.com/oracle-samples/oci-data-science-ai-samples/blob/main/ai-quick-actions/troubleshooting-tips.md). 
+
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+For more details, refer to the corresponding [Oracle release notes](https://docs.oracle.com/en-us/iaas/releasenotes/data-science/ai-quick-actions-106-b.htm).
+
+
 ## v1.0.6b (Released February 28, 2025)
 **Highlights:**
 - **Cached Model Upgrade:**


### PR DESCRIPTION
# Description
Adding release notes for AQUA `v1.0.7` and `v1.0.6d`

<img width="912" alt="Screenshot 2025-04-24 at 12 02 13 AM" src="https://github.com/user-attachments/assets/56c480d2-0cfc-40ca-a15d-b34c36036c39" />
<img width="1069" alt="Screenshot 2025-04-24 at 12 11 11 AM" src="https://github.com/user-attachments/assets/0287295a-1f02-45c1-b820-a8a403403020" />


