### PR TITLE
Multiple inference example for openai sdk auth

### DIFF
--- a/model-deployment/multiple_inference_endpoints/openai_sdk_auth/README.md
+++ b/model-deployment/multiple_inference_endpoints/openai_sdk_auth/README.md
@@ -1,0 +1,111 @@
+# OCI OpenAI SDK Auth
+
+This folder demonstrates how to use a custom authentication layer to enable OpenAI SDK compatibility with Oracle Cloud Infrastructure (OCI) Data Science Model Deployments, including support for streaming and non-streaming endpoints.
+
+## Overview
+
+The `oci_openai_auth` module provides a custom authentication class and a drop-in replacement for the OpenAI client, allowing you to use the OpenAI Python SDK with OCI model deployments that require request signing.
+
+### Key Components
+
+- **`oci_openai_auth/signer_auth_override.py`**  
+  Contains:
+  - `MyCustomAuth`: An `httpx.Auth` implementation that signs requests using OCI's security token and private key.
+  - `MultiInferOpenAI`: A subclass of `openai.OpenAI` that injects the custom authentication into all requests, making it compatible with OCI endpoints.
+
+- **`local_custom_auth.py`**  
+  Example script for using the custom OpenAI client with a standard (non-streaming) OCI model deployment endpoint.
+
+- **`local_custom_auth_streaming.py`**  
+  Example script for using the custom OpenAI client with a streaming OCI model deployment endpoint.
+
+## Installation
+
+Ensure you have the following dependencies installed:
+- `oci`
+- `openai`
+- `httpx`
+- `requests`
+
+You can install them via pip:
+```bash
+pip install oci openai httpx requests
+```
+
+## Usage
+
+### 1. Prepare OCI Config
+
+Make sure your `~/.oci/config` is set up with a valid profile, and that the profile includes a `security_token_file` and `key_file`.
+
+### 2. Using the Custom OpenAI Client
+
+#### Non-Streaming Example
+
+See `local_custom_auth.py` for a full example. The key steps are:
+
+```python
+from oci_openai_auth.signer_auth_override import MultiInferOpenAI
+
+# Get OCI signer (see local_custom_auth.py for details)
+signer = get_oci_signer()
+
+# Set your model deployment OCID and endpoint
+mdocid = '<your-model-deployment-ocid>'
+predict_endpoint = f'https://<host>:<port>/{mdocid}/predict/v1'
+
+# Initialize the custom OpenAI client
+custom_oci_openai = MultiInferOpenAI(
+    oci_signer=signer,
+    api_key='',
+    base_url=predict_endpoint
+)
+
+# Make a chat completion request
+response = custom_oci_openai.chat.completions.create(
+    model='/opt/ds/model/deployed_model',
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me something interesting."}
+    ],
+    max_tokens=500
+)
+print(response)
+```
+
+#### Streaming Example
+
+See `local_custom_auth_streaming.py` for a full example. The main difference is the endpoint and the use of `stream=True`:
+
+```python
+predict_streaming_endpoint = f'https://<host>:<port>/{mdocid}/predictWithResponseStream/v1'
+
+custom_oci_openai = MultiInferOpenAI(
+    oci_signer=signer,
+    api_key='',
+    base_url=predict_streaming_endpoint
+)
+
+response = custom_oci_openai.chat.completions.create(
+    model='/opt/ds/model/deployed_model',
+    messages=[{"role": "user", "content": "Stream me a story."}],
+    stream=True,
+    max_tokens=1000
+)
+
+for chunk in response:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="", flush=True)
+```
+
+## How it Works
+
+- The custom `MyCustomAuth` class signs each HTTP request using OCI's security token and private key.
+- `MultiInferOpenAI` injects this authentication into all OpenAI SDK requests, making it seamless to use OpenAI SDK methods with OCI endpoints.
+
+## Notes
+
+- SSL verification is disabled by default for local testing. **Remove or set `verify=True` in production.**
+- Logging is set to DEBUG for detailed output; adjust as needed.
+- The scripts assume you have a deployed model in OCI Data Science and the correct permissions.

--- a/model-deployment/multiple_inference_endpoints/openai_sdk_auth/local_custom_auth.py
+++ b/model-deployment/multiple_inference_endpoints/openai_sdk_auth/local_custom_auth.py
@@ -1,0 +1,55 @@
+import oci
+import logging
+from oci_openai_auth.signer_auth_override import MultiInferOpenAI
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def get_oci_signer():
+    # Get oci signer
+    config = oci.config.from_file(profile_name='default')
+    token_file = config['security_token_file']
+    token = None
+    with open(token_file, 'r') as f:
+        token = f.read()
+    private_key = oci.signer.load_private_key_from_file(config['key_file'])
+    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    return signer
+
+signer = get_oci_signer()
+
+
+# -------------- Getting paths ready -----------------
+ssl = True
+mdocid = '<your-model-deployment-ocid>'
+predict_endpoint = f'https://localhost:8888/{mdocid}/predict/v1' if ssl else f'http://localhost:8888/{mdocid}/predict/v1'
+logger.info(f'predict_endpoint: {predict_endpoint}')
+
+# -------------- OpenAI Client Init -----------------
+custom_oci_openai = MultiInferOpenAI(
+    oci_signer=signer,
+    api_key='',
+    base_url=predict_endpoint
+)
+
+# Chat Completions
+response = custom_oci_openai.chat.completions.create(
+    model='/opt/ds/model/deployed_model',
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant working in Oracle Cloud Infrastructure."},
+        {"role": "user", "content": "Tell me the most interesting fact about your time working at OCI."}
+    ],
+    max_tokens=500
+)
+
+# Models List
+models = custom_oci_openai.models.list()
+for model in models:
+    logger.info(f'Model: {model.id}')
+
+print('-----------------------------------')
+print(f'Completions Response received: {response}')
+print('-----------------------------------')
+
+

--- a/model-deployment/multiple_inference_endpoints/openai_sdk_auth/local_custom_auth_streaming.py
+++ b/model-deployment/multiple_inference_endpoints/openai_sdk_auth/local_custom_auth_streaming.py
@@ -1,0 +1,59 @@
+import oci
+import logging
+from oci_openai_auth.signer_auth_override import MultiInferOpenAI
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def get_oci_signer():
+    # Get oci signer
+    config = oci.config.from_file(profile_name='default')
+    token_file = config['security_token_file']
+    token = None
+    with open(token_file, 'r') as f:
+        token = f.read()
+    private_key = oci.signer.load_private_key_from_file(config['key_file'])
+    signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+    return signer
+
+signer = get_oci_signer()
+
+
+# -------------- Getting paths ready -----------------
+ssl = True
+mdocid = '<your-model-deployment-ocid>'
+predict_endpoint = f'https://localhost:8888/{mdocid}/predict/v1' if ssl else f'http://localhost:8888/{mdocid}/predict/v1'
+predict_streaming_endpoint = f'https://localhost:8888/{mdocid}/predictWithResponseStream/v1' if ssl else f'http://localhost:8888/{mdocid}/predictWithResponseStream/v1'
+print(f'predict_endpoint: {predict_endpoint}')
+print(f'predict_streaming_endpoint: {predict_streaming_endpoint}')
+
+# -------------- OpenAI Client Init -----------------
+custom_oci_openai = MultiInferOpenAI(
+    oci_signer=signer,
+    api_key='',
+    base_url=predict_streaming_endpoint
+)
+
+# Chat Completions
+response = custom_oci_openai.chat.completions.create(
+    model='/opt/ds/model/deployed_model',
+    messages=[
+        {"role": "user", "content": "Write a big essay on the history of Oracle Cloud Infrastructure."}
+    ],
+    stream=True, # -> False
+    max_tokens=1000
+)
+
+full_response = ""
+for chunk in response:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        full_response += delta
+        print(delta, end="", flush=True)
+
+print('-----------------------------------')
+print(f'Response received: {response}')
+print('-----------------------------------')
+
+

--- a/model-deployment/multiple_inference_endpoints/openai_sdk_auth/oci_openai_auth/signer_auth_override.py
+++ b/model-deployment/multiple_inference_endpoints/openai_sdk_auth/oci_openai_auth/signer_auth_override.py
@@ -1,0 +1,106 @@
+import oci
+from oci.signer import Signer
+import httpx
+from openai._base_client import BaseClient
+from openai import OpenAI
+import requests
+import logging
+import sys
+from email.utils import formatdate
+import time
+import hashlib
+import base64
+import json
+
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+# Set to DEBUG to see detailed logs, INFO for standard logs
+DEBUG_MODE = True  # Toggle this to True/False to enable/disable debug logs
+if DEBUG_MODE:
+    logger.setLevel(logging.DEBUG)
+    # Also set console handler to DEBUG to see debug messages
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+
+# Create console handler with formatting
+formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)
+
+# -------------- Get oci signer -----------------
+config = oci.config.from_file(profile_name='default')
+token_file = config['security_token_file']
+token = None
+with open(token_file, 'r') as f:
+    token = f.read()
+private_key = oci.signer.load_private_key_from_file(config['key_file'])
+signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+
+
+# Custom auth class
+class MyCustomAuth(httpx.Auth):
+    def __init__(self, signer):
+        self.signer = signer
+
+    def auth_flow(self, request):
+        logger.debug("Starting custom auth flow")
+
+        required_headers = {
+            **dict(request.headers),
+        }
+
+        # Convert httpx.Request to requests.PreparedRequest
+        req = requests.Request(
+            method=request.method,
+            url=str(request.url),
+            headers=required_headers,
+            data=request.content  # Use content to ensure consistency
+        )
+
+        prepared = req.prepare()
+        logger.debug(f'Prepared URL: {prepared.url}')
+        
+        # Log headers at debug level
+        for k, v in prepared.headers.items():
+            logger.debug(f'OpenAI default header ➡️: {k}: {v}')
+
+        # Sign the request using the signer
+        signed_prepared = self.signer(prepared)
+
+        # Update httpx.Request with signed headers and body
+        request.headers.clear()  # Clear existing headers
+        request.headers.update(signed_prepared.headers)
+        
+        # Always set Content-Length header
+        if signed_prepared.body:
+            request.stream = httpx.ByteStream(signed_prepared.body)  # Use ByteStream to set the body
+            if 'content-length' not in request.headers:
+                request.headers['content-length'] = str(len(signed_prepared.body))
+        else:
+            # For requests without body (like GET), set Content-Length to 0
+            request.headers['content-length'] = '0'
+        
+        logger.debug(f'Signed prepared URL: {signed_prepared.url}')
+        # Log signed headers at debug level
+        for k, v in request.headers.items():
+            logger.debug(f'Custom OCI signed header ⬅️: {k}: {v}')
+
+        yield request
+
+# Custom openai class
+class MultiInferOpenAI(OpenAI):
+    def __init__(self, oci_signer, *args, **kwargs):
+        kwargs['http_client'] = httpx.Client(verify=False)  # Disable SSL verification for local testing (TODO: remove this for prod)
+        super().__init__(*args, **kwargs)
+        self.signer = oci_signer
+    
+    @property
+    def custom_auth(self) -> httpx.Auth | None:
+        return MyCustomAuth(self.signer)


### PR DESCRIPTION
This new folder has examples for multiple inference client code snippets. 
Currently adding an example to show how we can call multiple inference OCI backed with OpenAI SDK (with OCI auth override)