### PR TITLE
[ODSC-74843] ORM stack update

### DIFF
--- a/ai-quick-actions/policies/terraform/iam.tf
+++ b/ai-quick-actions/policies/terraform/iam.tf
@@ -74,7 +74,7 @@ locals {
 
   all_buckets = concat(var.user_model_buckets, var.user_data_buckets)
   bucket_names = join(", ", formatlist("target.bucket.name='%s'", local.all_buckets))
-  bucket_names_oss = join(", ", formatlist("all{target.bucket.name='%s', any {request.permission='OBJECT_CREATE', request.permission='OBJECT_INSPECT'}}", local.all_buckets))
+  bucket_names_oss = join(", ", formatlist("target.bucket.name='%s'", local.all_buckets))
   dt_jr_policies = local.is_resource_policy_required?[
     "Allow dynamic-group id ${oci_identity_dynamic_group.distributed_training_job_runs[0].id} to use logging-family in ${local.compartment_policy_string}",
     "Allow dynamic-group id ${oci_identity_dynamic_group.distributed_training_job_runs[0].id} to manage data-science-models in ${local.compartment_policy_string}",


### PR DESCRIPTION
# Description
When users apply AQUA policies via ORM stack, the following policies are added for allowing MD/Jobs to access the user bucket.

```
Allow dynamic-group id ocid1.dynamicgroup.oc1..<ocid> to manage object-family in compartment id ocid1.compartment.oc1..<ocid> where any {all{target.bucket.name='<bucket-name>', any {request.permission='OBJECT_CREATE', request.permission='OBJECT_INSPECT'}}, all{target.bucket.name='<bucket-name>', any {request.permission='OBJECT_CREATE', request.permission='OBJECT_INSPECT'}}} 
```
 

This resulted in MD unable to access the fine tuned model artifacts coming from user bucket, confirmed by the following error:

```
LM : Unable to get artifact part : Error returned by ObjectStorage Service. Http Status Code: 404. Error Code: BucketNotFound. Opc request id: iad-1:5H9wOnuOWKCE_ot0CxNXJIdj7RaWRI0gPacjw0co9hw6DsplpxFBoMDHtHOCplZ9. Message: Either the bucket named 'ds-auqa' does not exist in the namespace 'idcsb7s2rt9t' or you are not authorized to access it
Operation Name: GetObject
Timestamp: 2025-07-08 22:19:12 +0000 GMT
Client Version: Oracle-GoSDK/65.4.0
Request Endpoint: GET https://objectstorage.us-ashburn-1.oraclecloud.com/n/idcsb7s2rt9t/b/ds-auqa/o/model/ocid1.datasciencejob.oc1.iad.amaaaaaaiaknepiahv4bq554gchp36rvdvci4wkqcbvr6vapc3djkculhtjq/README.md?versionId=a17cdb63-a393-427a-8b64-18bd3f31d1a1
Troubleshooting Tips: See https://docs.oracle.com/iaas/Content/API/References/apierrors.htm#apierrors_404__404_bucketnotfound for more information about resolving this error.
Also see https://docs.oracle.com/iaas/api/#/en/objectstorage/20160918/Object/GetObject for details on this operation's requirements.
To get more info on the failing request, you can set OCI_GO_SDK_DEBUG env var to info or higher level to log the request/response details.
If you are unable to resolve this ObjectStorage issue, please contact Oracle support and provide them this full error message. 
```
 

The above policy needs to be removed and replaced with less restrictive policy.


`Allow dynamic-group id ocid1.dynamicgroup.oc1..<ocid> to manage object-family in compartment id ocid1.compartment.oc1..<ocid> where any {target.bucket.name='<bucket-name>'} `