### PR TITLE
Update Release Notes for v1.0.8a–v1.0.8e

### DIFF
--- a/ai-quick-actions/release-notes.md
+++ b/ai-quick-actions/release-notes.md
@@ -1,5 +1,68 @@
 # AI Quick Actions Release Notes
 
+## v1.0.8e (Released August 20, 2025)
+**Highlights:**
+- **Cached Model Upgrade – OpenAI Open Weight Models:**
+  - Added cached support for OpenAI’s new open-weight models (gpt-oss-120b, gpt-oss-20b). 
+  - Models are available for deployment and fine-tuning without importing artifacts, supported in service-managed containers with the latest vLLM. 
+  - gpt-oss-120b: 117B parameters (5.1B active), optimized for production and high-reasoning. 
+  - gpt-oss-20b: 21B parameters (3.6B active), optimized for low-latency and specialized workloads. 
+  - Deliver strong performance on tool use, few-shot function calling, CoT reasoning, and HealthBench.
+
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+---
+
+## v1.0.8d (Released August 4, 2025)
+**Highlights:**
+- **Model Deployment Enhancements:**
+  - Added streaming endpoint integration for model deployments, enabling real-time inferencing with lower latency.
+- **Cached Model Upgrades:**
+  - Granite Speech 3.3 (Speech-to-Text): Upload audio (≤4 MB) in the Inference Playground to run speech-to-text with one click.
+  - Granite Timeseries TTM R1: New model for advanced time series forecasting.
+- **CLI Enhancements:**
+  - Added policy verification tools to simplify validation of security and access policies.
+- **Preview Models:**
+  - Granite 4.0 (Text-to-Text): Preview model with improved NLP performance.
+
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+---
+
+## v1.0.8c (Released July 24, 2025)
+**Highlights:**
+- **Platform Expansion:**
+  - AI Quick Actions is now available in Government (Gov) and Oracle National Security Regions (ONSR), supporting compliance, security, and localized deployments.
+- **Cached Model Upgrade:**
+  - Added cached model support for Llama 3.2 and Llama 4, available for immediate deployment and fine-tuning without registration.
+
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+---
+
+## v1.0.8b (Released July 21, 2025)
+**Highlights:**
+- **UI Enhancements:**
+  - Bring Your Own Reservation (BYOR) Support:
+    - Customers can now view and use existing GPU reservations directly in AI Quick Actions. 
+    - Workloads can be launched seamlessly without manual coordination or transfers.
+
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+---
+
+## v1.0.8a (Released June 26, 2025)
+**Highlights:**
+ - **Cached Model Upgrade – Granite 3 Models Support:**
+   - Added support for IBM’s Granite 3 models as service cached models, available directly in the Model Explorer for deployment and fine-tuning. 
+   - Granite-3.3-2b-Instruct: 2B parameters, 128K context, tuned for reasoning and instruction following. 
+   - Granite-3.3-8b-Instruct / GGUF: 8B parameters, 128K context; GGUF variant supports CPU. 
+   - Granite-Vision-3.2-2b: Vision-language model for document understanding (tables, charts, diagrams, infographics). 
+   - Granite-Embedding-278m-multilingual: Embedding model for high-quality multilingual text representations.
+ 
+To get this version of AI Quick Actions, deactivate and reactivate your notebook sessions.
+
+---
 
 ## v1.0.7a (Released May 29, 2025)
 **Highlights:**
@@ -27,7 +90,7 @@ To get this version of AI Quick Actions, deactivate and reactivate your notebook
 
 ---
 
-## v1.0.6d (Released February April 17, 2025)
+## v1.0.6d (Released April 17, 2025)
 **Highlights:**
 - **Cached Model Upgrade:**
   - Introduced Phi 4 and Phi 3.5 as a service cached model.


### PR DESCRIPTION
Included updates:

v1.0.8e (Aug 20, 2025): Added cached support for OpenAI open-weight models (gpt-oss-120b, gpt-oss-20b).

v1.0.8d (Aug 4, 2025): Streaming endpoint integration, Granite Speech 3.3 (speech-to-text), Granite Timeseries TTM R1, policy verification CLI tools, and Granite 4.0 preview.

v1.0.8c (Jul 24, 2025): Expansion to OCI Gov and ONSR regions, cached model support for Llama 3.2 and Llama 4.

v1.0.8b (Jul 21, 2025): Bring Your Own Reservation (BYOR) UI enhancement for GPU reservations.

v1.0.8a (Jun 26, 2025): Added cached support for IBM Granite 3 models (Instruct, Vision, and Embedding variants).